### PR TITLE
Fixed incomplete type error from the PanelArraySlot array declaration

### DIFF
--- a/src/SDK/panorama/IUIPanel.h
+++ b/src/SDK/panorama/IUIPanel.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include "types.h"
 
 namespace panorama


### PR DESCRIPTION
Fixed the compilation error where: 

> field` ‘slots’ has incomplete type ‘std::array<panorama::PanelArraySlot, 1024>’